### PR TITLE
Update README.md -- CS286 moved, no direct link to a reading list

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Columnar storage and column-oriented query engine are critical to analytical wor
 
 A number of schools have their own reading lists for graduate students in databases.
 
-* Berkeley [PhD prelim exam reading list](http://www.eecs.berkeley.edu/GradAffairs/CS/Prelims/db.html) and [CS286 grad database class reading list](http://www.cs286.net/home/reading-list)
+* Berkeley [PhD prelim exam reading list](http://www.eecs.berkeley.edu/GradAffairs/CS/Prelims/db.html) and [CS286 Graduate Database Systems](https://cs286berkeley.net/) class's readings (columns "Paper 1",	"Paper 2" and	"Additional Resources" on Syllabus)
 * [Brown CSCI 2270 Advanced Topics in Database Management](https://www.francosolleza.com/CS227/)
 * [Stanford PhD qualifying exam](http://infolab.stanford.edu/db_pages/infoqual.html)
 * MIT: [Database Systems 6.830 year 2010](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-830-database-systems-fall-2010/readings/)


### PR DESCRIPTION
The website for CS286 moved to https://cs286berkeley.net/, and there's no direct link to a reading list anymore.
The readings are now distributed in the syllabus. I've fixed the link and rewritten that info.